### PR TITLE
Fixed hostnames binding mismatch

### DIFF
--- a/AppService.Acmebot/RenewCertificatesFunctions.cs
+++ b/AppService.Acmebot/RenewCertificatesFunctions.cs
@@ -84,7 +84,9 @@ namespace AppService.Acmebot
                     log.LogInformation($"Subject name: {certificate.SubjectName}");
 
                     // IDN に対して証明書を発行すると SANs に Punycode 前の DNS 名が入るので除外
-                    var dnsNames = certificate.HostNames.Where(x => !x.Contains(" (")).ToArray();
+                    var dnsNames = certificate.HostNames
+                                              .Where(x => !x.Contains(" (") && site.HostNames.Contains(x))
+                                              .ToArray();
 
                     // 証明書を発行し Azure にアップロード
                     var newCertificate = await context.CallSubOrchestratorAsync<Certificate>(nameof(SharedFunctions.IssueCertificate), (site, dnsNames));

--- a/AppService.Acmebot/SharedFunctions.cs
+++ b/AppService.Acmebot/SharedFunctions.cs
@@ -145,7 +145,7 @@ namespace AppService.Acmebot
             }
 
             return list.Where(x => x.State == "Running")
-                       .Where(x => x.HostNameSslStates.Any(xs => !xs.Name.EndsWith(".azurewebsites.net") && !xs.Name.EndsWith(".trafficmanager.net")))
+                       .Where(x => x.HostNames.Any(xs => !xs.EndsWith(".azurewebsites.net") && !xs.EndsWith(".trafficmanager.net")))
                        .ToArray();
         }
 


### PR DESCRIPTION
Preventing mismatch between SANs and App Service bound hostnames in certificates.

https://github.com/shibayan/appservice-acmebot/issues/181#issuecomment-640602123