### PR TITLE
Adding PreferredChain options

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,6 +17,8 @@ indent_size = 2
 
 # C# files
 [*.cs]
+charset = utf-8-bom
+
 # New line preferences
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true

--- a/AppService.Acmebot/Internal/AccountKey.cs
+++ b/AppService.Acmebot/Internal/AccountKey.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 using ACMESharp.Crypto.JOSE;
 

--- a/AppService.Acmebot/Internal/AcmeProtocolClientExtensions.cs
+++ b/AppService.Acmebot/Internal/AcmeProtocolClientExtensions.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+using ACMESharp.Protocol;
+
+namespace AppService.Acmebot.Internal
+{
+    internal static class AcmeProtocolClientExtensions
+    {
+        public static async Task<X509Certificate2Collection> GetOrderCertificateAsync(this AcmeProtocolClient acmeProtocolClient, OrderDetails order,
+                                                                                      string preferredChain = null, CancellationToken cancel = default)
+        {
+            IEnumerable<string> linkHeaders;
+            X509Certificate2Collection defaultX509Certificates;
+
+            using (var resp = await acmeProtocolClient.GetAsync(order.Payload.Certificate, cancel))
+            {
+                defaultX509Certificates = await resp.Content.ReadAsCertificatesAsync();
+
+                // 証明書チェーンが未指定、もしくはデフォルトのチェーンの場合は即返す
+                if (preferredChain == null || defaultX509Certificates.Find(X509FindType.FindByIssuerName, preferredChain, true).Count > 0)
+                {
+                    return defaultX509Certificates;
+                }
+
+                linkHeaders = resp.Headers.GetValues("Link");
+            }
+
+            foreach (var linkHeader in linkHeaders)
+            {
+                // Link ヘッダーから alternate で指定されている URL を拾ってくる
+                var rel = Regex.Match(linkHeader, "(?<=rel=\").+?(?=\")", RegexOptions.IgnoreCase);
+
+                if (!string.Equals(rel.Value, "alternate", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var url = Regex.Match(linkHeader, "(?<=<).+?(?=>)", RegexOptions.IgnoreCase);
+
+                // 代替の証明書をダウンロードする
+                using (var resp = await acmeProtocolClient.GetAsync(url.Value, cancel))
+                {
+                    var x509Certificates = await resp.Content.ReadAsCertificatesAsync();
+
+                    // 指定された証明書チェーンに一致する場合は返す
+                    if (x509Certificates.Find(X509FindType.FindByIssuerName, preferredChain, true).Count > 0)
+                    {
+                        return x509Certificates;
+                    }
+                }
+            }
+
+            // マッチする証明書チェーンが存在しない場合はデフォルトを返す
+            return defaultX509Certificates;
+        }
+    }
+}

--- a/AppService.Acmebot/Internal/X509Certificate2Extensions.cs
+++ b/AppService.Acmebot/Internal/X509Certificate2Extensions.cs
@@ -1,5 +1,7 @@
-using System;
+﻿using System;
+using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 
 namespace AppService.Acmebot.Internal
 {
@@ -29,6 +31,17 @@ namespace AppService.Acmebot.Internal
 
                 rawDataSpan = rawDataSpan.Slice(foundIndex + EndCertificate.Length);
             }
+        }
+
+        public static async Task<X509Certificate2Collection> ReadAsCertificatesAsync(this HttpContent httpContent)
+        {
+            var certificateData = await httpContent.ReadAsByteArrayAsync();
+
+            var x509Certificates = new X509Certificate2Collection();
+
+            x509Certificates.ImportFromPem(certificateData);
+
+            return x509Certificates;
         }
     }
 }

--- a/AppService.Acmebot/Options/AcmebotOptions.cs
+++ b/AppService.Acmebot/Options/AcmebotOptions.cs
@@ -18,5 +18,7 @@ namespace AppService.Acmebot.Options
 
         [Required]
         public string Environment { get; set; } = "AzureCloud";
+
+        public string PreferredChain { get; set; }
     }
 }

--- a/AppService.Acmebot/SharedFunctions.cs
+++ b/AppService.Acmebot/SharedFunctions.cs
@@ -473,12 +473,7 @@ namespace AppService.Acmebot
             var finalize = await acmeProtocolClient.FinalizeOrderAsync(orderDetails.Payload.Finalize, csr);
 
             // 証明書をバイト配列としてダウンロード
-            var certificateData = await acmeProtocolClient.GetOrderCertificateAsync(finalize);
-
-            // X509Certificate2Collection を作成
-            var x509Certificates = new X509Certificate2Collection();
-
-            x509Certificates.ImportFromPem(certificateData);
+            var x509Certificates = await acmeProtocolClient.GetOrderCertificateAsync(finalize, _options.PreferredChain);
 
             // 秘密鍵を含んだ形で X509Certificate2 を作成
             x509Certificates[0] = x509Certificates[0].CopyWithPrivateKey(rsa);

--- a/AppService.Acmebot/Startup.cs
+++ b/AppService.Acmebot/Startup.cs
@@ -91,7 +91,15 @@ namespace AppService.Acmebot
 
             builder.Services.AddOptions<AcmebotOptions>()
                    .Bind(section.Exists() ? section : context.Configuration.GetSection("LetsEncrypt"))
-                   .ValidateDataAnnotations();
+                   .ValidateDataAnnotations()
+                   .PostConfigure(options =>
+                   {
+                       // Backward compatibility
+                       if (options.Endpoint == "https://acme-v02.api.letsencrypt.org/")
+                       {
+                           options.PreferredChain ??= "DST Root CA X3";
+                       }
+                   });
         }
     }
 }

--- a/AppService.Acmebot/StaticPageFunctions.cs
+++ b/AppService.Acmebot/StaticPageFunctions.cs
@@ -1,4 +1,4 @@
-using Azure.WebJobs.Extensions.HttpApi;
+﻿using Azure.WebJobs.Extensions.HttpApi;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;


### PR DESCRIPTION
- Adding `Acmebot:PreferredChain` option
  - `DST Root CA X3` (default, backward compatibility after 2020/9/30)
  - `ISRG Root X1` (future default)

https://community.letsencrypt.org/t/workflow-for-using-alternate-link-relation/129321