### PR TITLE
add the root route

### DIFF
--- a/AppService.Acmebot/proxies.json
+++ b/AppService.Acmebot/proxies.json
@@ -6,6 +6,12 @@
         "route": "add-certificate"
       },
       "backendUri": "http://localhost/api/static-page/add-certificate"
+    },
+    "Root": {
+      "matchCondition": {
+        "route": "/"
+      },
+      "backendUri": "http://localhost/api/static-page/add-certificate"
     }
   }
 }


### PR DESCRIPTION
Add the root route to the `/add-certificate`

using the add-certificate page as the homepage.

1. show this page instead of the 404 page when opening this website
2. users need not remember and typing the route /add-certificate.